### PR TITLE
feat: allow additional reserved fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,29 @@ logging.debug("starting application...")
 
 You can optionally customize the name of these additional fields using a [`logging.Filter`](https://docs.python.org/3/library/logging.html#filter-objects) (see below).
 
+Similarily, you can choose to ignore additional attributes passed via the `extra` keyword argument. This can be usefull to e.g. not log keywords named `secret` or `password`.
+
+To do so, pass a list of names to the `ignored_attrs` keyword when initializing a `GelfFormatter`. You can also modify the `ignored_attrs` instance variable of an already initialized formatter.
+
+##### Example
+
+But be aware: nested fields will be printed! Only the root level of keywords is filtered by the `ignored_attrs`.
+
+```python
+attrs = ["secret", "password"]
+
+formatter = GelfFormatter(ignored_attrs=attrs)
+# or
+formatter.ignored_attrs = attrs
+
+logging.debug("app config", extra={"connection": "local", "secret": "verySecret!", "mysql": {"user": "test", "password": "will_be_logged"}})
+```
+
+```text
+{"version": "1.1", "short_message": "app config", "timestamp": 1557346554.989846, "level": 6, "host": "my-server", "_connection": "local", "_mysql": {"user": "test", "password": "will_be_logged"}}
+```
+
+
 #### Context Fields
 
 Having the ability to define a set of additional fields once and have them included in all log messages can be useful to avoid repetitive `extra` key/value pairs and enable contextual logging.

--- a/gelfformatter/formatter.py
+++ b/gelfformatter/formatter.py
@@ -82,8 +82,8 @@ class GelfFormatter(logging.Formatter):
         allowed_reserved_attrs: A list of reserved `logging.LogRecord`_ attributes that
         should not be ignored but rather included as additional fields.
 
-        ignored_attrs: A list of additional attributes passed to a `logging.LogRecord`_ via
-        the `extra` keyword that will be ignored in addition to the reserved fields
+        ignored_attrs: A list of additional attributes passed to a `logging.LogRecord`_
+        via the `extra` keyword that will be ignored in addition to the reserved fields
         and not be present in the ouput.
 
     .. _logging.Formatter:

--- a/gelfformatter/formatter.py
+++ b/gelfformatter/formatter.py
@@ -95,7 +95,9 @@ class GelfFormatter(logging.Formatter):
         self.allowed_reserved_attrs = allowed_reserved_attrs
         self._hostname = socket.gethostname()
 
-        self._reserved_attrs = [attr for attr in RESERVED_ATTRS if attr not in self.allowed_reserved_attrs]
+        self._reserved_attrs = [
+            x for x in RESERVED_ATTRS if x not in self.allowed_reserved_attrs
+        ]
         self._reserved_attrs += additional_reserved_attrs
 
     def format(self, record):

--- a/gelfformatter/formatter.py
+++ b/gelfformatter/formatter.py
@@ -82,8 +82,9 @@ class GelfFormatter(logging.Formatter):
         allowed_reserved_attrs: A list of reserved `logging.LogRecord`_ attributes that
         should not be ignored but rather included as additional fields.
 
-        ignored_attrs: A list of additional `logging.LogRecord`_ attributes that will be
-        ignored in addition to the reserved fields and not be present in the ouput.
+        ignored_attrs: A list of additional attributes passed to a `logging.LogRecord`_ via
+        the `extra` keyword that will be ignored in addition to the reserved fields
+        and not be present in the ouput.
 
     .. _logging.Formatter:
        https://docs.python.org/3/library/logging.html#logging.Formatter

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -147,9 +147,7 @@ class TestGelfFormatter(TestCase):
         )
 
     def testAdditionalReservedAttrs(self):
-        formatter = GelfFormatter(
-            additional_reserved_attrs=["secret"]
-        )
+        formatter = GelfFormatter(additional_reserved_attrs=["secret"])
         self.log_handler.setFormatter(formatter)
 
         self.logger.info(MSG, extra={"allowed": "it is", "secret": "denied"})
@@ -163,7 +161,7 @@ class TestGelfFormatter(TestCase):
                 "timestamp": TIME,
                 "host": HOST,
                 "level": 6,
-                "_allowed": "it is"
+                "_allowed": "it is",
             },
         )
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -146,6 +146,27 @@ class TestGelfFormatter(TestCase):
             },
         )
 
+    def testAdditionalReservedAttrs(self):
+        formatter = GelfFormatter(
+            additional_reserved_attrs=["secret"]
+        )
+        self.log_handler.setFormatter(formatter)
+
+        self.logger.info(MSG, extra={"allowed": "it is", "secret": "denied"})
+
+        gelf = json.loads(self.buffer.getvalue())
+        self.assertEqual(
+            gelf,
+            {
+                "version": "1.1",
+                "short_message": MSG,
+                "timestamp": TIME,
+                "host": HOST,
+                "level": 6,
+                "_allowed": "it is"
+            },
+        )
+
 
 class TestUtilityMethods(TestCase):
     def testUnderscorePrefix(self):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -147,7 +147,7 @@ class TestGelfFormatter(TestCase):
         )
 
     def testAdditionalReservedAttrs(self):
-        formatter = GelfFormatter(additional_reserved_attrs=["secret"])
+        formatter = GelfFormatter(ignored_attrs=["secret"])
         self.log_handler.setFormatter(formatter)
 
         self.logger.info(MSG, extra={"allowed": "it is", "secret": "denied"})


### PR DESCRIPTION
Hi João,
really nice formatter you have got there going! Short, concise, well setup, exactly what I needed!

I would like to add a small piece of functionality. The GelfFormatter already allows with allowed_reserved_attrs to re-allow attributes. I use this regularily, but in some cases I would like to add attributes to that list, in essence filtering them from the output. My use case is e.g. my applications logs its configuration on startup but i would like to filter fields like 'secret' or 'key', just to be sure not to disclose any secrets in my logs.
I am aware that filtering like this is not perfect (e.g. dumping nested dicts would only filter one level) but IMHO that would be out of scope for a logging formatter. I think this solution is in scope, as the user should be allowed to configure RESERVED_ATTRS in both directions.

**Thank your for your work!**

Greets,
Christoph