### PR TITLE
feat: add tests for py38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ jobs:
       python: '3.6'
       script: make test
     - stage: test
+      python: '3.8'
+      script: make test
+    - stage: test
       python: '3.7'
       script: make coverage
       after_success: codecov

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: System :: Logging",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37
+envlist = py27, py35, py36, py37, py38
 
 [testenv]            
 commands = python setup.py test


### PR DESCRIPTION
Hi there again,
this simply adds python 3.8 to the tested and compatible versions of this project.
I have added it as a simple test stage, keeping coverage and publish on 3.7. If everything works fine, one can switch this later.