### PR TITLE
WIP: feat: implement multiple stages

### DIFF
--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -180,6 +180,33 @@ class TestGelfFormatter(TestCase):
             },
         )
 
+    def testAdditionalReservedAttrsRec(self):
+        formatter = GelfFormatter(ignored_attrs=["secret"])
+        self.log_handler.setFormatter(formatter)
+
+        self.logger.info(
+            MSG,
+            extra={
+                "allowed": "it is",
+                "secret": "denied",
+                "a": {"secret": "b", "good": "c"},
+            },
+        )
+
+        gelf = json.loads(self.buffer.getvalue())
+        self.assertEqual(
+            gelf,
+            {
+                "version": "1.1",
+                "short_message": MSG,
+                "timestamp": TIME,
+                "host": HOST,
+                "level": 6,
+                "_allowed": "it is",
+                "_a": {"good": "c"},
+            },
+        )
+
 
 class TestUtilityMethods(TestCase):
     def testUnderscorePrefix(self):


### PR DESCRIPTION
First: this PR is **not** intended to be merged. I just threw some code together to test and play how implementing this may look like. But a PR provides a nice way to discuss changed code.

So over Christmas I had some time to think about how to implement #6 and #7. In the end I did the following:

1. Pull the `format` method apart into `prepare_basic`, `get_optionals` and the `format` method itself.
2. Move the filter-logic to a separat method.

It now seems like more code, but it's mostly docstrings. There was only one change in functionality, the recursive filtering.

The goals where:
- Make logic more composable (for subclassing the formatter)
- Allow for recursive filtering

### Good
I think pulling the logic into separate methods is a good thing. Even though it makes everything look larger and one has to search for logic in multiple places, it isn't that large of a file and enables composability and locality.
I decided to implement recursive filtering first, as I still don't know how to do targeted filtering in sub-dicts in a simple way.

### Bad:
The `filter` method. I think it is still ugly. The API seems a little clunky, naming is unclear (key, value vs k, v) and those 3 return statements 😆.
Additionally it doesn't resolve #6. It does not target specific entries in subdict, it just recursively selects items to be filtered. But IMHO the possibility of subclassing the `GelfFormatter` and just implementing the `filter` method with custom filter logic may be enough for a lot of use cases.

I would love to get your feedback! I would then open new PRs, taking your feedback and implementing the changes cleanly to be merged into master.

Hope you had a nice Christmas and a happy new year to you!
Chris