### PR TITLE
chore: remove obsolete tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,0 @@
-[tox]
-envlist = py36, py37, py38, py39
-
-[testenv]            
-commands = python setup.py test


### PR DESCRIPTION
Removes the obsolete `tox.ini` file that was left over from before the migration to `pyproject.toml` and GitHub Actions CI. The file referenced Python 3.6-3.9 and `setup.py test`, neither of which are used anymore. CI now uses GitHub Actions with `uv` and `pytest` for Python 3.10-3.14.